### PR TITLE
rip fireden

### DIFF
--- a/archives.json
+++ b/archives.json
@@ -62,16 +62,6 @@
   "boards": ["a", "aco", "an", "c", "co", "d", "fit", "int", "k", "m", "mlp", "qa", "r9k", "tg", "vr", "wsg"],
   "files": ["a", "aco", "an", "c", "co", "d", "fit", "int", "k", "m", "mlp", "qa", "r9k", "tg", "vr", "wsg"]
 }, {
-  "uid": 24,
-  "name": "fireden.net",
-  "domain": "boards.fireden.net",
-  "http": false,
-  "https": true,
-  "software": "foolfuuka",
-  "boards": ["cm", "ic", "vg", "y"],
-  "files": ["cm", "ic", "vg", "y"],
-  "search": []
-}, {
   "uid": 25,
   "name": "arch.b4k.co",
   "domain": "arch.b4k.co",


### PR DESCRIPTION
```
$ curl -v http://boards.fireden.net/
* Hostname was NOT found in DNS cache
*   Trying 2400:cb00:2048:1::681c:445...
* Connected to boards.fireden.net (2400:cb00:2048:1::681c:445) port 80 (#0)
> GET / HTTP/1.1
> User-Agent: curl/7.38.0
> Host: boards.fireden.net
> Accept: */*
>
< HTTP/1.1 302 Found
< Date: Mon, 12 Oct 2015 10:51:50 GMT
< Content-Type: text/html; charset=iso-8859-1
< Transfer-Encoding: chunked
< Connection: keep-alive
< Set-Cookie: __cfduid=d9a47963ba67bb8b97f6cbd9e0ffb7d2c1444647110; expires=Tue, 11-Oct-16 10:51:50 GMT; path=/; domain=.fireden.net; HttpOnly
< Location: http://nonexiste.net/
< X-Content-Type-Options: nosniff
* Server cloudflare-nginx is not blacklisted
< Server: cloudflare-nginx
< CF-RAY: 23424076ccb314d3-CDG
<
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="http://nonexiste.net/">here</a>.</p>
<hr>
<address>Apache/2.4.7 (Ubuntu) Server at boards.fireden.net Port 80</address>
</body></html>
* Connection #0 to host boards.fireden.net left intact
```