### PR TITLE
Love is Over is back.

### DIFF
--- a/archives.json
+++ b/archives.json
@@ -70,4 +70,14 @@
   "software": "foolfuuka",
   "boards": ["g", "jp", "mlp", "v"],
   "files": []
+}, {
+  "uid": 5,
+  "name": "Love is Over",
+  "domain": "deploy.loveisover.me",
+  "http": true,
+  "https": false,
+  "software": "foolfuuka",
+  "boards": ["c", "d", "e", "i", "lgbt", "t", "u"],
+  "files": ["c", "d", "e", "i", "lgbt", "t", "u"],
+  "search": []
 }]


### PR DESCRIPTION
I haven't heard anything from @theBladeee yet, so I don't know if the hostname change is permanent, but it's been up there for a few days now, and it's the only archive for /i/, /lgbt/, /t/, and /u/, so I think we should add it if there are no objections. If the hostname changes, we can always update that later.

HTTPS support doesn't seem to be working yet, so I've moved it to the end of the list temporarily to avoid it becoming the default for /c/, /d/, and /e/, which would cause some users problems with mixed content restrictions.
