### PR TITLE
Add b-stats archive

### DIFF
--- a/archives.json
+++ b/archives.json
@@ -80,4 +80,13 @@
   "boards": ["c", "d", "e", "i", "lgbt", "t", "u"],
   "files": ["c", "d", "e", "i", "lgbt", "t", "u"],
   "search": []
+}, {
+  "uid": 26,
+  "name": "bstats",
+  "domain": "archive.b-stats.org",
+  "http": true,
+  "https": true,
+  "software": "foolfuuka",
+  "boards": ["f", "cm", "hm", "lgbt", "news", "trash", "y"],
+  "files": []
 }]

--- a/archives.json
+++ b/archives.json
@@ -81,7 +81,7 @@
   "files": ["c", "d", "e", "i", "lgbt", "t", "u"],
   "search": []
 }, {
-  "uid": 26,
+  "uid": 28,
   "name": "bstats",
   "domain": "archive.b-stats.org",
   "http": true,


### PR DESCRIPTION
Technically it's not foolfuuka but I've made the URLs and API work. Some boards have been archiving longer than many other existing archives. Files aren't indexed yet but are mostly saved, so I may add that in later.