### PR TITLE
Changed yeet.net DNS

### DIFF
--- a/archives.json
+++ b/archives.json
@@ -126,11 +126,10 @@
   "files": ["c", "d", "e", "i", "lgbt", "t", "u"]
 }, {
   "uid": 33,
-  "name": "yeet.net",
+  "name": "Bui's Archive (Mirror)",
   "domain": "yeet.net",
   "http": true,
   "https": false,
   "software": "foolfuuka",
-  "boards": ["g", "k", "qa"],
-  "files": ["g", "k", "qa"]
+  "boards": ["b"]
 }]

--- a/archives.json
+++ b/archives.json
@@ -127,9 +127,17 @@
 }, {
   "uid": 33,
   "name": "Bui's /b/ Archive (Mirror)",
-  "domain": "yeet.net",
+  "domain": "bui.yeet.net",
   "http": true,
   "https": false,
   "software": "foolfuuka",
   "boards": ["b"]
+}, {
+  "uid": 34,
+  "name": "YEET Archive",
+  "domain": "archive.yeet.net",
+  "http": true,
+  "https": false,
+  "software": "foolfuuka",
+  "boards": ["g", "k", "qa"]
 }]

--- a/archives.json
+++ b/archives.json
@@ -126,18 +126,18 @@
   "files": ["c", "d", "e", "i", "lgbt", "t", "u"]
 }, {
   "uid": 33,
-  "name": "Bui's /b/ Archive (Mirror)",
-  "domain": "bui.yeet.net",
-  "http": true,
-  "https": false,
-  "software": "foolfuuka",
-  "boards": ["b"]
-}, {
-  "uid": 34,
   "name": "YEET Archive",
   "domain": "archive.yeet.net",
   "http": true,
   "https": false,
   "software": "foolfuuka",
   "boards": ["g", "k", "qa"]
+}, {
+  "uid": 34,
+  "name": "Bui's /b/ Archive (Mirror)",
+  "domain": "bui.yeet.net",
+  "http": true,
+  "https": false,
+  "software": "foolfuuka",
+  "boards": ["b"]
 }]

--- a/archives.json
+++ b/archives.json
@@ -126,7 +126,7 @@
   "files": ["c", "d", "e", "i", "lgbt", "t", "u"]
 }, {
   "uid": 33,
-  "name": "Bui's Archive (Mirror)",
+  "name": "Bui's /b/ Archive (Mirror)",
   "domain": "yeet.net",
   "http": true,
   "https": false,

--- a/archives.md
+++ b/archives.md
@@ -33,5 +33,6 @@ uid | name | domain | software
 `30`|`TheBArchive.com`|[thebarchive.com](http://thebarchive.com)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
 `31`|`Archive Of Sins`|[archiveofsins.com](http://archiveofsins.com)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
 `32`|`4tan`|[boards.4tan.org](https://boards.4tan.org)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
-`33`|`Bui's /b/ Archive (Mirror)`|[yeet.net](http://bui.yeet.net)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
 `33`|`YEET Archive`|[yeet.net](http://archive.yeet.net)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
+`34`|`Bui's /b/ Archive (Mirror)`|[yeet.net](http://bui.yeet.net)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
+

--- a/archives.md
+++ b/archives.md
@@ -33,4 +33,4 @@ uid | name | domain | software
 `30`|`TheBArchive.com`|[thebarchive.com](http://thebarchive.com)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
 `31`|`Archive Of Sins`|[archiveofsins.com](http://archiveofsins.com)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
 `32`|`4tan`|[boards.4tan.org](https://boards.4tan.org)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
-`33`|`yeet.net`|[yeet.net](http://yeet.net)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
+`33`|`Bui's /b/ Archive (Mirror)`|[yeet.net](http://yeet.net)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)

--- a/archives.md
+++ b/archives.md
@@ -33,4 +33,5 @@ uid | name | domain | software
 `30`|`TheBArchive.com`|[thebarchive.com](http://thebarchive.com)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
 `31`|`Archive Of Sins`|[archiveofsins.com](http://archiveofsins.com)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
 `32`|`4tan`|[boards.4tan.org](https://boards.4tan.org)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
-`33`|`Bui's /b/ Archive (Mirror)`|[yeet.net](http://yeet.net)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
+`33`|`Bui's /b/ Archive (Mirror)`|[yeet.net](http://bui.yeet.net)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)
+`33`|`YEET Archive`|[yeet.net](http://archive.yeet.net)|[FoolFuuka](https://github.com/FoolCode/FoolFuuka)


### PR DESCRIPTION
The live archive and Bui's mirror are both hosted on the yeet.net domain.